### PR TITLE
Improved data transmission robustness by assigning a new data id to each data value sent by emitter.

### DIFF
--- a/lib/LoRaPrivate/LoRaCfg.h
+++ b/lib/LoRaPrivate/LoRaCfg.h
@@ -15,10 +15,10 @@
 //#define SYNC_WORD 0x00            //Syncronization byte
 //#define PREAM_LEN 8               //Signal preamble length
 
-#define IN_BUFFER_SIZE      255     //Maximum number of bytes per input packet
+#define IN_BUFFER_SIZE      255U    //Maximum number of bytes per input packet
 
 #define GATEWAY_ID          0x53AC  //ID that all emmiters must use to communicate with gateway
-#define GATEWAY_ID_LEN      2       //Number of bytes that compose the gateway ID
+#define GATEWAY_ID_LEN      2U      //Number of bytes that compose the gateway ID
 
 #define ACK_TIMEOUT         5000U   //Acknowledgment timeout (ms)
 

--- a/lib/LoRaPrivate/LoRaPrivate.cpp
+++ b/lib/LoRaPrivate/LoRaPrivate.cpp
@@ -13,6 +13,8 @@ volatile bool Cad_isr_responded = false;
 volatile bool channel_busy = true;
 volatile bool ack_received = false;
 
+RTC_DATA_ATTR uint8 previous_did = 0xFF;
+
 //Encapsules the whole LoRa configuration. Returns 0 if successful, 1 if error.
 uint8 LoRaConfig(void)
 {
@@ -125,6 +127,21 @@ uint8 replyAck(void)
 
   LoRa.receive(); //reenter receive mode
   return err_reg;
+}
+
+//Checks if the data ID of the newly received packet is different from the last one.
+//If this is the case, the data value is new.
+//Returns false if data is new, true if data is duplicated.
+bool isDataDuplicated(void)
+{
+  bool returner = true;
+  if(in_packet[GATEWAY_ID_LEN + 1U] != previous_did)
+  {
+    returner = false;
+    previous_did = in_packet[GATEWAY_ID_LEN + 1U];
+  }
+
+  return returner;
 }
 
 /*NOT USED

--- a/lib/LoRaPrivate/LoRaPrivate.h
+++ b/lib/LoRaPrivate/LoRaPrivate.h
@@ -6,6 +6,7 @@
 
 uint8 LoRaConfig(void);
 bool isChannelBusy(void);
+bool isDataDuplicated(void);
 uint8 sendPacket(uint8* packet, uint16 packet_len);
 //uint8 awaitAck(void);
 uint8 replyAck(void);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,9 +11,11 @@ RTC_DATA_ATTR uint8 new_value = 31;
 RTC_DATA_ATTR uint8 old_value = 0;
 
 RTC_DATA_ATTR uint16 ack_fails = 0;
-RTC_DATA_ATTR uint16 not_four_bytes = 0;
-RTC_DATA_ATTR uint16 missed_value = 0;
-RTC_DATA_ATTR uint16 repeated_value = 0;
+RTC_DATA_ATTR uint16 not_five_bytes = 0;
+RTC_DATA_ATTR uint16 missed_data = 0;
+RTC_DATA_ATTR uint16 duplicated_data = 0;
+
+RTC_DATA_ATTR uint8 previous_did = 0xFF;
 
 void setup() {
 
@@ -54,41 +56,47 @@ void setup() {
 void loop(){
   if(in_packet_len)
   {
-    if(replyAck())
+    if(in_packet_len == 5)
     {
-      Serial.println("Failed to reply with acknowledgement");
-      ack_fails++;
+      if(replyAck())
+      {
+        Serial.println("Failed to reply with acknowledgement");
+        ack_fails++;
+      }
+
+      if(in_packet[3] != previous_did)
+      {
+        old_value = new_value;
+        new_value = in_packet[4];
+
+        if (((old_value + 1) % 32) != new_value)
+        {
+          missed_data++;
+        }
+
+        previous_did = in_packet[3];
+
+        //(void)uploadValue("received_value", new_value);
+      }
+      else
+      {
+        Serial.println("Received data was duplicated");
+        duplicated_data++;
+      }
     }
+    else
+    {
+      Serial.println("Not 5 bytes received");
+      not_five_bytes++;
+    }
+
     Serial.print("Received string: ");
     printStr((uint8*)in_packet, in_packet_len);
     Serial.println();
     Serial.print("With length: ");
     Serial.println(in_packet_len);
-   
-    if(in_packet_len == 4)
-    {
-      old_value = new_value;
-      new_value = in_packet[3];
-
-      if (((old_value + 1) % 32) != new_value)
-      {
-        missed_value++;
-      }
-
-      if(old_value == new_value)
-      {
-        repeated_value++;
-        //(void)EmailSend("20240227_1 test", "An email is sent because a repeated value has been received.");
-      }
-      
-    }
-    else
-    {
-      Serial.println("More than 4 bytes received");
-      not_four_bytes++;
-    }
     Serial.println();
-    //(void)uploadValue("received_value", new_value);
+
     in_packet_len = 0;
   }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,8 +15,6 @@ RTC_DATA_ATTR uint16 not_five_bytes = 0;
 RTC_DATA_ATTR uint16 missed_data = 0;
 RTC_DATA_ATTR uint16 duplicated_data = 0;
 
-RTC_DATA_ATTR uint8 previous_did = 0xFF;
-
 void setup() {
 
   Serial.begin(115200);
@@ -56,7 +54,7 @@ void setup() {
 void loop(){
   if(in_packet_len)
   {
-    if(in_packet_len == 5)
+    if(in_packet_len == GATEWAY_ID_LEN + 3U)
     {
       if(replyAck())
       {
@@ -64,24 +62,22 @@ void loop(){
         ack_fails++;
       }
 
-      if(in_packet[3] != previous_did)
+      if(isDataDuplicated())
+      {
+        Serial.println("Received data was duplicated");
+        duplicated_data++;
+      }
+      else
       {
         old_value = new_value;
-        new_value = in_packet[4];
-
+        new_value = in_packet[GATEWAY_ID_LEN + 2U];
+        
         if (((old_value + 1) % 32) != new_value)
         {
           missed_data++;
         }
 
-        previous_did = in_packet[3];
-
         //(void)uploadValue("received_value", new_value);
-      }
-      else
-      {
-        Serial.println("Received data was duplicated");
-        duplicated_data++;
       }
     }
     else


### PR DESCRIPTION
 - If emitter receives ack, a new random data id (did) will be generated and sent with the new data. The new did can be any number from 0 to 254, except the previous did.
 - If emitter fails to receive ack, the data and did will not change.
 - did of 255 is reserved.

This way, the next time the data is transmitted:

 - If the message did not reach the gateway the first time, it will this time. The did will tell the gateway that the data is new for it.
 - If the message did reach to gateway, but the ack replay failed the first time, on the second time the gateway can detect a duplicated value by comparing the received did with the previous one. If they coincide, the data is duplicated and sould not be uploaded to the data base.