### PR TITLE
Update time periodically via WiFi

### DIFF
--- a/lib/timePrivate/timeCfg.h
+++ b/lib/timePrivate/timeCfg.h
@@ -5,6 +5,7 @@
 //https://github.com/nayarsystems/posix_tz_db/blob/master/zones.csv
 #define TZ_INFO "CET-1CEST,M3.5.0,M10.5.0/3"
 
-#define TCUPD_TIMEOUT 20000U    //Time configuration update timeout (ms) 
+#define TCUPD_TIMEOUT 20000U    //Time configuration update timeout (ms)
+#define TUPD_PERIOD 1800U       //Period between time updates via WiFi (s)
 
 #endif //timeCfg_H

--- a/lib/timePrivate/timePrivate.cpp
+++ b/lib/timePrivate/timePrivate.cpp
@@ -3,6 +3,8 @@
 #include <timePrivate.h>
 #include <timeCfg.h>
 
+RTC_DATA_ATTR time_t last_updated;
+
 //Connects to external server to get UTC calendar time. Then, updates the time zone and prints the time. Timeout of TCUPD_TIMEOUT
 //Returns 0 if successful, 1 if error.
 uint8 timeConfigWiFi(void)
@@ -24,10 +26,9 @@ uint8 timeConfigWiFi(void)
     {
         setenv("TZ", TZ_INFO, 1);
         tzset();
-        time_t cldtime;
-        time(&cldtime);
+        time(&last_updated);
         Serial.print("Time is: ");
-        Serial.print(ctime(&cldtime));
+        Serial.print(ctime(&last_updated));
         return 0;
     }
     else
@@ -35,4 +36,76 @@ uint8 timeConfigWiFi(void)
         Serial.println("Could not update time (timeout reached).");
         return 1;
     }
+}
+
+//Looks up the last calendar time that time was updated and compares with current calendar time.
+//If the difference is greater than TUPD_PERIOD, it calls timeConfigWiFi to update time.
+//Returns 0 if update was not necessary, 1 if time has been updated, 2 if error. 
+uint8 checkTimeUpdate(void)
+{
+    time_t now;
+    time(&now);
+    if(now - last_updated < TUPD_PERIOD)
+    {
+        return 0;
+    }
+    else
+    {
+        return (timeConfigWiFi() + 1U);
+    }
+}
+
+//Puts the MCU to sleep, and wakes it up again after the specified amount of time has passed.
+void sleepFor(uint16 seconds, uint16 minutes, uint16 hours, uint16 days)
+{
+  uint64 total_time_us = 0;
+
+  total_time_us += 86400U * (uint64)days;
+  total_time_us += 3600U * (uint64)hours;
+  total_time_us += 60U * (uint64)minutes;
+  total_time_us += (uint64)seconds;
+    
+  total_time_us *= 1000000U; //conversion to us
+  Serial.print("Sleeping for ");
+  Serial.print(total_time_us / 1000000U);
+  Serial.println(" s");
+  esp_deep_sleep(total_time_us);
+}
+
+//Puts the MCU to sleep, and wakes it up again at the specified date and time.
+//Returns 1 if specified date is not in the future.
+uint8 sleepUntil(int year, int month, int day, int hour, int minute, int second)
+{
+  //insert date in tm struct with expected format
+  struct tm wakeup_date;
+
+  wakeup_date.tm_year = year - 1900;
+  wakeup_date.tm_mon = month - 1;
+  wakeup_date.tm_mday = day;
+  wakeup_date.tm_hour = hour;
+  wakeup_date.tm_min = minute;
+  wakeup_date.tm_sec = second;
+  wakeup_date.tm_isdst = -1;
+
+  time_t wakeup_cldtime = mktime(&wakeup_date); //get calendar time of wake up date
+  time_t current_cldtime;
+  time(&current_cldtime); //get current calendar time
+
+  if (wakeup_cldtime > current_cldtime)
+  {
+    //calculate number of us left for reaching wake up date
+    uint64 total_time_us = ((uint64)(wakeup_cldtime - current_cldtime)) * 1000000U;
+    Serial.print("Waking up on ");
+    Serial.print(asctime(&wakeup_date));
+
+    Serial.print("Sleeping for ");
+    Serial.print(total_time_us / 1000000U);
+    Serial.println(" s");
+    esp_deep_sleep(total_time_us);
+  }
+  else
+  {
+    Serial.println("Wake up date is not in the future");
+    return 1;
+  }
 }

--- a/lib/timePrivate/timePrivate.h
+++ b/lib/timePrivate/timePrivate.h
@@ -4,5 +4,8 @@
 #include <platformTypes.h>
 
 uint8 timeConfigWiFi(void);
+uint8 checkTimeUpdate(void);
+void sleepFor(uint16 seconds, uint16 minutes = 0U, uint16 hours = 0U, uint16 days = 0U);
+uint8 sleepUntil(int year, int month, int day, int hour, int minute, int second);
 
 #endif // timePrivate_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,13 +8,11 @@
 #include <timePrivate.h>
 #include <WiFiPrivate.h>
 
-RTC_DATA_ATTR uint8 new_value = 31;
-RTC_DATA_ATTR uint8 old_value = 0;
+RTC_DATA_ATTR uint16 new_value = 31;
 
 RTC_DATA_ATTR uint16 ack_fails = 0;
 RTC_DATA_ATTR uint16 cldtime_fails = 0;
 RTC_DATA_ATTR uint16 unexpected_num_bytes = 0;
-RTC_DATA_ATTR uint16 missed_data = 0;
 RTC_DATA_ATTR uint16 duplicated_data = 0;
 
 void setup() {
@@ -34,22 +32,22 @@ void setup() {
   {
     SwReset(10);
   }
-
+  
   //Connect to InfluxDB server
-  if (InfluxServerConnect())
-  {
-    SwReset(10);
-  }
+  //if (InfluxServerConnect())
+  //{
+  //  SwReset(10);
+  //}
 
   //Add tags
-  sensor.addTag("test", "LoRa_2minutes");
-  sensor.addTag("try", "20240227_1");
+  //sensor.addTag("test", "LoRa_5minutes");
+  //sensor.addTag("try", "20240308_1");
 
   //Configure and log into e-mail account
-  if (EmailConfig())
-  {
-    SwReset(10);
-  }
+  //if (EmailConfig())
+  //{
+  //  SwReset(10);
+  //}
 
   if (LoRaConfig())
   {
@@ -68,7 +66,7 @@ void loop(){
       //Do nothing
     }break;
 
-    case (GATEWAY_ID_LEN + 3U):
+    case (GATEWAY_ID_LEN + 4U):
     {
       if(replyAck())
       {
@@ -83,15 +81,14 @@ void loop(){
       }
       else
       {
-        old_value = new_value;
-        new_value = in_packet[GATEWAY_ID_LEN + 2U];
-        
-        if (((old_value + 1) % 32) != new_value)
-        {
-          missed_data++;
-        }
+        new_value = *((uint16*)(&in_packet[GATEWAY_ID_LEN + 2U]));
+        Serial.print("Received value: ");
+        Serial.println(new_value);
 
         //(void)uploadValue("received_value", new_value);
+        //(void)uploadValue("ack_fails", ack_fails);
+        //(void)uploadValue("unexpected_num_bytes", unexpected_num_bytes);
+        //(void)uploadValue("duplicated_data", duplicated_data);
       }
       break;
     }
@@ -127,4 +124,6 @@ void loop(){
 
     in_packet_len = 0;
   }
+
+  (void)checkTimeUpdate();
 }


### PR DESCRIPTION
It has been detected that the ESP32 ticks a bit faster than it should be: For every hour that passes, the MCU's RTC has counted 1 hour and 20 seconds. A new function in timePrivate.h with name checkTimeUpdate(void) has been implemented. It reads the time of last clock update from WiFi, and gets the current RTC time. If the difference is greater than TUPD_PERIOD (in seconds), then the already existing function timeConfigWifi() is called. This function is called from main repeatidly.

This means that the RTC will be updated every TUPD_PERIOD (in seconds). This is a #define set in timeCfg.h.

Also, the sleepFor and sleepUntil functions from the emitter project have been copied as utilities, and the main has been modified for the new tests.