### PR TITLE
Enable crc and upgraded timeouts

### DIFF
--- a/lib/LoRaPrivate/LoRaPrivate.cpp
+++ b/lib/LoRaPrivate/LoRaPrivate.cpp
@@ -35,6 +35,7 @@ uint8 LoRaConfig(void)
   //LoRa.setPreambleLength(PREAM_LEN);
   //LoRa.enableInvertIQ();
   //LoRa.setSyncWord(SYNC_WORD);
+  LoRa.enableCrc();
 
   LoRa.onCadDone(onCadDone); //call onCadDone ISR when channel activity detection has finished
   //LoRa.onTxDone(onTxDone); //call onTxDone ISR when packet has been fully sent

--- a/lib/WiFiPrivate/WiFiCfg.h
+++ b/lib/WiFiPrivate/WiFiCfg.h
@@ -4,4 +4,6 @@
 #define WIFI_SSID       "LAB243_exp"
 #define WIFI_PASSWORD   "123456789"
 
+#define WIFI_TIMEOUT    30000U          //WiFi connection timeout (ms)
+
 #endif // WiFiCfg_H

--- a/lib/WiFiPrivate/WiFiPrivate.cpp
+++ b/lib/WiFiPrivate/WiFiPrivate.cpp
@@ -14,15 +14,15 @@ uint8 WiFiConnect(void)
   WiFi.mode(WIFI_STA);
   wifiMulti.addAP(WIFI_SSID, WIFI_PASSWORD);
 
-  byte connection_timer = 0;
-  while ((wifiMulti.run() != WL_CONNECTED) and (connection_timer < 19)) {
-    connection_timer++;
+  uint32 start_time = millis();
+  while ((wifiMulti.run() != WL_CONNECTED) and ((millis() - start_time) < WIFI_TIMEOUT))
+  {
     Serial.print(".");
     delay(500);
   }
   Serial.println();
 
-  if (connection_timer > 18)
+  if (millis() - start_time >= WIFI_TIMEOUT)
   {
     Serial.println("Could not connect to WiFi (timeout reached).");
     return 1;

--- a/lib/influxDbClientPrivate/influxDbClientCfg.h
+++ b/lib/influxDbClientPrivate/influxDbClientCfg.h
@@ -8,4 +8,7 @@
 
 #define _MEASUREMENT        "LoRa"
 
+#define INFLUXDB_CON_TIMEOUT    60000U      //InfluxDB connection to server timeout (ms)
+#define INFLUXDB_UPL_TIMEOUT    10000U      //Data upload to InfluxDB server timeout (ms)
+
 #endif //influxDbClientCfg_H

--- a/lib/influxDbClientPrivate/influxDbClientPrivate.cpp
+++ b/lib/influxDbClientPrivate/influxDbClientPrivate.cpp
@@ -11,16 +11,15 @@ uint8 InfluxServerConnect(void)
 {
   Serial.print("Connecting to InfluxDB local server");
   int returner = 0;
-  byte connection_timer = 0;
+  uint32 start_time = millis();
 
-  while ((!client.validateConnection()) and (connection_timer < 2))
+  while ((!client.validateConnection()) and ((millis() - start_time) < INFLUXDB_CON_TIMEOUT))
   {
-    connection_timer++;
     Serial.print(".");
     delay(500);
   }
   Serial.println();
-  if (connection_timer > 1)
+  if ((millis() - start_time) >= INFLUXDB_CON_TIMEOUT)
   {
     Serial.print("Timeout reached. InfluxDB connection failed: ");
     Serial.println(client.getLastErrorMessage());
@@ -47,15 +46,14 @@ uint8 uploadValue(const String &field, uint8 value)
   sensor.clearFields();
   sensor.addField(field, value);
 
-  int upload_timer = 0;
-  while ((!client.writePoint(sensor)) and (upload_timer < 2))
+  uint32 start_time = millis();
+  while ((!client.writePoint(sensor)) and ((millis() - start_time) < INFLUXDB_UPL_TIMEOUT))
   {
-    upload_timer++;
     Serial.print(".");
-    delay(500);
+    delay(300);
   }
   Serial.println();
-  if (upload_timer > 1)
+  if ((millis() - start_time) >= INFLUXDB_UPL_TIMEOUT)
   {
     Serial.print("Timeout reached. InfluxDB write failed: ");
     Serial.println(client.getLastErrorMessage());

--- a/lib/mailClientPrivate/mailClientCfg.h
+++ b/lib/mailClientPrivate/mailClientCfg.h
@@ -11,6 +11,8 @@
 #define AUTHOR_PASSWORD "yajhwpxuyhmmhrdd"
 
 #define RECIPIENT_NAME  "esp32 sender"
-#define RECIPIENT_EMAIL "espsender1@gmail.com" // Recipient's email
+#define RECIPIENT_EMAIL "espsender1@gmail.com"  // Recipient's email
+
+#define CON_TIMEOUT     5000U                   //Timeout for all connections to e-mail server 
 
 #endif //mailClientCfg_H

--- a/lib/mailClientPrivate/mailClientPrivate.cpp
+++ b/lib/mailClientPrivate/mailClientPrivate.cpp
@@ -32,7 +32,7 @@ uint8 EmailConfig(void)
   return 0;
 }
 
-//Tries to log into the e-mail account specified in EmailConfig.
+//Tries to log into the e-mail account specified in EmailConfig. Returns 0 if successful, 1 if error
 uint8 EmailLogIn(void)
 {
   Serial.print("Logging into e-mail account");
@@ -81,7 +81,7 @@ uint8 EmailLogIn(void)
   return returner;
 }
 
-//Tries to send an e-mail. Returns 1 if successful, 0 if error.
+//Tries to send an e-mail. Returns 0 if successful, 1 if error.
 uint8 EmailSend(String subject, String textMsg)
 {
   //Log in e-mail account

--- a/lib/mailClientPrivate/mailClientPrivate.cpp
+++ b/lib/mailClientPrivate/mailClientPrivate.cpp
@@ -37,14 +37,13 @@ uint8 EmailLogIn(void)
 {
   Serial.print("Logging into e-mail account");
   int returner = 0;
-  int connection_timer = 0;
-  while ((!smtp.connect(&config)) and (connection_timer < 2))
+  uint32 start_time = millis();
+  while ((!smtp.connect(&config)) and ((millis() - start_time) < CON_TIMEOUT))
   {
-    connection_timer++;
     Serial.print(".");
-    delay(500);
+    delay(300);
   }
-  if (connection_timer > 1)
+  if ((millis() - start_time) >= CON_TIMEOUT)
   {
     Serial.println();
     Serial.print("Timeout reached. ");
@@ -52,14 +51,13 @@ uint8 EmailLogIn(void)
     returner = 1;
   }
 
-  connection_timer = 0;
-  while ((!smtp.isLoggedIn()) and (connection_timer < 2))
+  start_time = millis();
+  while ((!smtp.isLoggedIn()) and ((millis() - start_time) < CON_TIMEOUT))
   {
-    connection_timer++;
     Serial.print(".");
-    delay(500);
+    delay(300);
   }
-  if (connection_timer > 1)
+  if ((millis() - start_time) >= CON_TIMEOUT)
   {
     Serial.println();
     Serial.println("Timeout reached. Not logged in mail account.");
@@ -67,15 +65,14 @@ uint8 EmailLogIn(void)
   }
   else
   {
-    connection_timer = 0;
-    while ((!smtp.isAuthenticated()) and (connection_timer < 2))
+    start_time = millis();
+    while ((!smtp.isAuthenticated()) and ((millis() - start_time) < CON_TIMEOUT))
     {
-      connection_timer++;
       Serial.print(".");
-      delay(500);
+      delay(300);
     }
     Serial.println();
-    if (connection_timer > 1)
+    if ((millis() - start_time) >= CON_TIMEOUT)
     {
       Serial.println("Timeout reached. Connected to mail service with no Auth.");
       returner = 1;
@@ -104,17 +101,16 @@ uint8 EmailSend(String subject, String textMsg)
   /* Start sending Email and close the session */
   Serial.print("Sending e-mail");
 
-  int send_counter = 0;
-  while ((!MailClient.sendMail(&smtp, &message, true)) and (send_counter < 2))
+  uint32 start_time = millis();
+  while ((!MailClient.sendMail(&smtp, &message, true)) and ((millis() - start_time) < CON_TIMEOUT))
   {
-    send_counter++;
     Serial.print(".");
-    delay(500);
+    delay(300);
   }
   Serial.println();
-  if (send_counter > 1)
+  if ((millis() - start_time) >= CON_TIMEOUT)
   {
-    ESP_MAIL_PRINTF("Error, Status Code: %d, Error Code: %d, Reason: %s", smtp.statusCode(), smtp.errorCode(), smtp.errorReason().c_str());
+    ESP_MAIL_PRINTF("Error (timeout reached). Status Code: %d, Error Code: %d, Reason: %s", smtp.statusCode(), smtp.errorCode(), smtp.errorReason().c_str());
     return 1;
   }
   return 0;


### PR DESCRIPTION
 - Various functions that previously had pseudotimeouts (actually just retry counters) now have full-on timeouts, configurable in the thingCfg.h file. All of them have been tested and work.
 - Enabled Crc in LoRaConfig.h. See https://github.com/Arcadi-dCC/esp32-LoRa-emitter0/pull/5 for more details.